### PR TITLE
add support for API level >= 18

### DIFF
--- a/app/src/main/java/com/brandonnalls/mockmocklocations/OverrideSettingsSecure.java
+++ b/app/src/main/java/com/brandonnalls/mockmocklocations/OverrideSettingsSecure.java
@@ -1,6 +1,7 @@
 package com.brandonnalls.mockmocklocations;
 
 import android.content.ContentResolver;
+import android.os.Build;
 import android.provider.Settings;
 
 import de.robv.android.xposed.IXposedHookLoadPackage;
@@ -10,14 +11,27 @@ import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
 
 public class OverrideSettingsSecure implements IXposedHookLoadPackage {
     public void handleLoadPackage(final LoadPackageParam lpparam) throws Throwable {
-
-        findAndHookMethod("android.provider.Settings.Secure", lpparam.classLoader, "getString", ContentResolver.class, String.class, new XC_MethodHook() {
-            @Override
-            protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
-                String requested = (String) param.args[1];
-                if (requested.equals(Settings.Secure.ALLOW_MOCK_LOCATION)) {
-                    param.setResult("0");
+        // before API level 18, hook Settings.Secure.ALLOW_MOCK_LOCATION
+        if (Build.VERSION.SDK_INT < 18) {
+            findAndHookMethod("android.provider.Settings.Secure", lpparam.classLoader, "getString",
+                    ContentResolver.class, String.class, new XC_MethodHook() {
+                @Override
+                protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                    String requested = (String) param.args[1];
+                    if (requested.equals(Settings.Secure.ALLOW_MOCK_LOCATION)) {
+                        param.setResult("0");
+                    }
                 }
+            });
+            return;
+        }
+
+        // after API level 18, hook Location.isFromMockProvider
+        findAndHookMethod("android.location.Location", lpparam.classLoader, "isFromMockProvider",
+                new XC_MethodHook() {
+            @Override
+            protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+                param.setResult(false);
             }
         });
     }

--- a/app/src/main/java/com/brandonnalls/mockmocklocations/OverrideSettingsSecure.java
+++ b/app/src/main/java/com/brandonnalls/mockmocklocations/OverrideSettingsSecure.java
@@ -11,28 +11,27 @@ import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
 
 public class OverrideSettingsSecure implements IXposedHookLoadPackage {
     public void handleLoadPackage(final LoadPackageParam lpparam) throws Throwable {
-        // before API level 18, hook Settings.Secure.ALLOW_MOCK_LOCATION
-        if (Build.VERSION.SDK_INT < 18) {
-            findAndHookMethod("android.provider.Settings.Secure", lpparam.classLoader, "getString",
-                    ContentResolver.class, String.class, new XC_MethodHook() {
-                @Override
-                protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
-                    String requested = (String) param.args[1];
-                    if (requested.equals(Settings.Secure.ALLOW_MOCK_LOCATION)) {
-                        param.setResult("0");
-                    }
-                }
-            });
-            return;
-        }
-
-        // after API level 18, hook Location.isFromMockProvider
-        findAndHookMethod("android.location.Location", lpparam.classLoader, "isFromMockProvider",
-                new XC_MethodHook() {
-            @Override
-            protected void afterHookedMethod(MethodHookParam param) throws Throwable {
-                param.setResult(false);
+        // Settings.Secure.ALLOW_MOCK_LOCATION is depprecated at API level 23
+        findAndHookMethod("android.provider.Settings.Secure", lpparam.classLoader, "getString",
+                ContentResolver.class, String.class, new XC_MethodHook() {
+                    @Override
+                    protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                        String requested = (String) param.args[1];
+                        if (requested.equals(Settings.Secure.ALLOW_MOCK_LOCATION)) {
+                            param.setResult("0");
+                        }
             }
         });
+
+        // at API level 18, the function Location.isFromMockProvider is added
+        if (Build.VERSION.SDK_INT >= 18) {
+            findAndHookMethod("android.location.Location", lpparam.classLoader, "isFromMockProvider",
+                    new XC_MethodHook() {
+                        @Override
+                        protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                            param.setResult(false);
+                        }
+            });
+        }
     }
 }


### PR DESCRIPTION
At API level 18, a new function Location.isFromMockProvider
is added for detect mock location
